### PR TITLE
A very slight fix for python3.

### DIFF
--- a/src/hieroglyph/__init__.py
+++ b/src/hieroglyph/__init__.py
@@ -1,5 +1,5 @@
-import builder
-import directives
+from hieroglyph import builder
+from hieroglyph import directives
 
 def setup(app):
 

--- a/src/hieroglyph/directives.py
+++ b/src/hieroglyph/directives.py
@@ -3,7 +3,7 @@ from docutils import nodes
 from sphinx.util.nodes import set_source_info
 from sphinx.util.compat import Directive
 
-import builder
+from hieroglyph import builder
 
 
 class slides(nodes.Element): pass


### PR DESCRIPTION
I tried installing "hieroglyph" in python 2.7.3 and python 3.2.3. 
Installing is success, but I can't build a slide in python3: could not import "builder.py".

It seems that this modification does not affect the behavior of "hieroglyph" in python 2.x.
