### PR TITLE
Support presenter notes

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -340,6 +340,33 @@ building other targets. The latter, in particular, may be used to
 include notes that you'd like to print with HTML or PDF output, but
 not include in the slides.
 
+Presenter Notes
+---------------
+
+.. slide:: Presenter Notes
+   :level: 2
+
+   Use the :rst:dir:`note` directive to insert "presenter notes" that
+   are only visible on the presenter console.
+
+   ::
+
+      .. note::
+
+         * Make sure to mention the important background story for
+           this slide.
+
+Use the :rst:dir:`note` directive to insert "presenter notes" that are
+only visible on the presenter console. Full reStructuredText
+formatting is supported within the notes.
+
+::
+
+   .. note::
+
+      * Make sure to mention the important background story for
+        this slide.
+
 Viewing Your Slides
 ===================
 

--- a/src/hieroglyph/themes/slides/console.html
+++ b/src/hieroglyph/themes/slides/console.html
@@ -9,3 +9,5 @@
 {% endblock %}
 
 {%- block slide_container_class %}table{%- endblock %}
+
+{%- block presenter_notes %}<div class="presenter_notes" id="presenter_notes">notes go here</div>{% endblock %}

--- a/src/hieroglyph/themes/slides/layout.html
+++ b/src/hieroglyph/themes/slides/layout.html
@@ -112,5 +112,6 @@
 
 {% block body %} {% endblock %}
 </section>
+{% block presenter_notes %}{% endblock %}
   </body>
 </html>

--- a/src/hieroglyph/themes/slides/static/console.css
+++ b/src/hieroglyph/themes/slides/static/console.css
@@ -42,3 +42,19 @@ article.placeholder {
 
     margin-top: 60px;
 }
+
+div.presenter_notes {
+	position: absolute;
+	top: 420px;
+	left: 10%;
+	background-color: white;
+	color: black;
+	padding: 1em;
+	width: 80%;
+	font-size: 130%;
+
+	border-radius: 10px;
+	-o-border-radius: 10px;
+	-moz-border-radius: 10px;
+	-webkit-border-radius: 10px;
+}

--- a/src/hieroglyph/themes/slides/static/console.js
+++ b/src/hieroglyph/themes/slides/static/console.js
@@ -35,6 +35,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
         document.querySelector('#slide_container').innerHTML =  prev_slide + cur_slide + next_slide;
 
+        // Copy the presenter notes into place
+        document.querySelector('#presenter_notes').innerHTML = $('article.current').find('div.admonition').html();
+
         var slides = document.querySelector('section.slides > article');
         for (var i=0; i < slides.length; i++) {
 

--- a/src/hieroglyph/themes/slides/static/slides.css
+++ b/src/hieroglyph/themes/slides/static/slides.css
@@ -40,3 +40,7 @@ div.figure p.caption {
     right: 1em;
     font-size: 66%;
 }
+
+div.admonition {
+	visibility: hidden;
+}


### PR DESCRIPTION
Allow slides using the "note" directive to contain
presenter notes that are displayed only in the presenter
console.

Signed-off-by: Doug Hellmann doug.hellmann@gmail.com
