### PR TITLE
Resolve improper page break handling in chromium slide printing

### DIFF
--- a/src/hieroglyph/themes/slides/static/styles.css
+++ b/src/hieroglyph/themes/slides/static/styles.css
@@ -712,6 +712,7 @@ article.smaller q::after {
 
         margin: auto;
         page-break-after: always;
+        page-break-inside: avoid;
 
         transform: none;
         -o-transform: none;


### PR DESCRIPTION
When printing, Chromium puts a page break inside slides; by adding "page-break-inside: avoid;" to styles.css @media print, this is resolved
