### PR TITLE
More presenter notes cleanups

### DIFF
--- a/src/hieroglyph/themes/slides/layout.html
+++ b/src/hieroglyph/themes/slides/layout.html
@@ -115,7 +115,11 @@
 
 {% block body %} {% endblock %}
 </section>
+
+<section id="slide_notes">
 {% block presenter_notes %}{% endblock %}
+</section>
+
     {%- if not embedded %}
     {{ script() }}
     {%- endif %}

--- a/src/hieroglyph/themes/slides/static/console.css
+++ b/src/hieroglyph/themes/slides/static/console.css
@@ -58,3 +58,7 @@ div.presenter_notes {
 	-moz-border-radius: 10px;
 	-webkit-border-radius: 10px;
 }
+
+div.presenter_notes p.admonition-title {
+	display: none;
+}


### PR DESCRIPTION
Add a section tag around the presenter notes div. It's not clear
why, but this seems necessary to have the notes actually appear
in the presenter console view.

Hide the redundant "Note" title on the presenter note view.

Change-Id: I111c7cbfd4e404f7ff97341123585c2dfc893cd6
