### PR TITLE
Specify lower-bound Sphinx version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 version = '0.7'
 
 install_requires = [
-    "Sphinx >= 1.2",
+    "Sphinx >= 1.1",
     "six",
 ]
 


### PR DESCRIPTION
Hieroglyph with Sphinx 1.0 will error out:

```
Exception occurred:
  File "/usr/local/lib/python2.7/dist-packages/hieroglyph-0.6.5-py2.7.egg/hieroglyph/builder.py", line 46, in init_templates
    warn=self.warn)
TypeError: init_themes() takes exactly 2 arguments (4 given)
```

some old distributions provide an outdated sphinx, but because hieroglyph only depends on _Sphinx_ `pip` or `easy_install` will consider that the requirement is fulfilled when installing hieroglyph, then it'll blow up at runtime.

Sphinx 1.1 may work, I have not checked.
