### PR TITLE
Convert rST block_quote to html5slides <q> elements

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -301,6 +301,26 @@ Hieroglyph introductory slide deck uses the following markup::
 The caption (license information above) is styled as an overlay on the
 image.
 
+Quotes
+------
+
+.. slide:: Quotes
+   :level: 2
+
+     reStructuredText quotes are automatically converted
+
+     -- whoever this is
+
+.. slide:: Quotes
+   :level: 2
+
+     Attribution is optional
+
+A standard reStructuredText quote will be interpreted as a quote slide,
+multiple quotes or additional content (on the same slide) are not supported.
+
+The attribution is standard rST, and optional.
+
 The ``slide`` directive
 -----------------------
 

--- a/src/hieroglyph/writer.py
+++ b/src/hieroglyph/writer.py
@@ -263,6 +263,34 @@ class BaseSlideTranslator(HTMLTranslator):
             self.pop_body()
             self.body.append(title)
 
+    def visit_block_quote(self, node):
+        # first child must be a paragraph, process it as a <q> element
+        p = node.children[0]
+        if p.tagname != 'paragraph':
+            raise ValueError("The first child of a quote must be a paragraph")
+        self.body.append(self.starttag(node, 'q'))
+        for text_item in p:
+            text_item.walkabout(self)
+        self.body.append('</q>\n')
+
+        if len(node.children) > 2:
+            raise ValueError("A quote can only have 2 children, the quote text"
+                             " and an attribution")
+        # optional second child must be an attribution, processing as a <div>
+        # following the <q>
+        if len(node.children) > 1:
+            attr = node.children[1]
+            if attr.tagname != 'attribution':
+                raise ValueError("The second child of a quote must be"
+                                 " an attribution")
+
+            self.body.append(self.starttag(attr, 'div', CLASS="author"))
+            for text_item in attr:
+                text_item.walkabout(self)
+            self.body.append('</div>\n')
+
+        # skip all normal processing
+        raise nodes.SkipNode
 
 class SlideTranslator(BaseSlideTranslator):
 


### PR DESCRIPTION
- rST supports quotes through the `block_quote` node (with an optional `attribution` child). The default HTML builders generate a `blockquote` element
- html5slides supports "quote" slides, but uses the `q` element (optionally followed with a `div[@class="author"]`)

Add a `block_quote` visitor to `BaseSlideTranslator` to generate a `q` element.

Restriction: only accept a single paragraph (required) and an optional attribution, html5slides's styling does not gracefully handles block elements for quotes, only inline elements in a `q`.

Fixes #72
