### PR TITLE
Added google analytics support

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -91,7 +91,7 @@ Themes
 
    Theme specific options as a ``dict``.
 
-   See :ref:`custom-css` for more information.
+   See :ref:`slide-theme-options` for more information.
 
 .. confval:: slide_theme_path
 
@@ -101,6 +101,42 @@ Themes
 
 For more information on styling and themes, see
 :ref:`hieroglyph-themes`.
+
+
+.. _slide-theme-options:
+
+Slide Theme Options
+===================
+
+The variable ``slide_theme_options`` can be used to configure a couple of
+aspects of the resulting HTML. The ``slides`` theme supports the following
+options.
+
+The value of this variable is a ``dict`` and can have the following keys:
+
+**custom_css**
+    A CSS file to load into the template. The file should be located in the
+    ``html_static_path`` folder (``_static`` by default). See also
+    :ref:`custom-css`.
+
+**custom_js**
+    A JS file to load into the template. The file should be located in the
+    ``html_static_path`` folder (``_static`` by default). See also
+    :ref:`custom-js`.
+
+**google_analytics**
+    A google analytics code (f.ex.: ``XX-12345-6``). If this value is set, the
+    analytics JS block is included in the resulting slides.
+
+
+.. code-block:: python
+    :caption: Example
+
+    slide_theme_options = {
+        'custom_css': 'mystyle.css',
+        'custom_js': 'myjavascript.js',
+        'google_analytics': 'XX-12345-6'
+    }
 
 
 .. _configuring-interlinking:

--- a/src/hieroglyph/tests/test_builder.py
+++ b/src/hieroglyph/tests/test_builder.py
@@ -32,6 +32,10 @@ class SlideBuilderTests(TestCase):
             'custom_js',
             resolved_theme_options,
         )
+        self.assertIn(
+            'google_analytics',
+            resolved_theme_options,
+        )
 
     @with_app()
     def test_get_theme_options_with_overrides(self, app, *args):
@@ -50,6 +54,7 @@ class SlideBuilderTests(TestCase):
             confoverrides={
                 'slide_theme_options': {
                     'custom_css': 'testing.css',
+                    'google_analytics': 'hello',
                 },
             },
         )
@@ -59,6 +64,11 @@ class SlideBuilderTests(TestCase):
         self.assertEqual(
             resolved_theme_options['custom_css'],
             'testing.css',
+        )
+
+        self.assertEqual(
+            resolved_theme_options['google_analytics'],
+            'hello',
         )
 
     @with_app(

--- a/src/hieroglyph/themes/slides/layout.html
+++ b/src/hieroglyph/themes/slides/layout.html
@@ -129,5 +129,18 @@
 {% block presenter_notes %}{% endblock %}
 </section>
 
+{% if theme_google_analytics %}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{theme_google_analytics}}', 'auto');
+  ga('send', 'pageview');
+
+</script>
+{% endif %}
+
   </body>
 </html>

--- a/src/hieroglyph/themes/slides/theme.conf
+++ b/src/hieroglyph/themes/slides/theme.conf
@@ -6,3 +6,4 @@ stylesheet = slides.css
 custom_css =
 custom_js =
 extra_pages_console = console.html
+google_analytics =


### PR DESCRIPTION
This PR implements a simple way to enable google-analytics by simply setting a variable in `slide_theme_options`.

As this variable is not *only* doing "styling" I also changes the docs a little bit, regrouping the possible options in one place. I have linked to the existing sections in `styling.rst`. Those are now a bit redundant. It might make sense to remove the "Adding JavaScript" section from `styling.rst` and link from the Custom CSS section into `config.rst` to avoid duplicating the docs.

Let me know what you think, and I will modify the PR accordingly.