### PR TITLE
slides2 theme prev/next areas and the slide hash

### DIFF
--- a/src/hieroglyph/themes/slides2/static/js/slide-deck.js
+++ b/src/hieroglyph/themes/slides2/static/js/slide-deck.js
@@ -424,13 +424,13 @@ SlideDeck.prototype.loadConfig_ = function(config) {
     var el = document.createElement('div');
     el.classList.add('slide-area');
     el.id = 'prev-slide-area';
-    el.addEventListener('click', this.prevSlide.bind(this), false);
+    el.addEventListener('click', this.prevSlide.bind(this,undefined), false);
     this.container.appendChild(el);
 
     var el = document.createElement('div');
     el.classList.add('slide-area');
     el.id = 'next-slide-area';
-    el.addEventListener('click', this.nextSlide.bind(this), false);
+    el.addEventListener('click', this.nextSlide.bind(this,undefined), false);
     this.container.appendChild(el);
   }
 


### PR DESCRIPTION
In the slides2 theme, let the prev/next slide areas change the hash number, so reloading the page returns to the current slide.

Before this change, the event is passed to the function and evaluated as "dontPush" when updating the hash.  Specifying that argument as undefined gets around this problem.