### PR TITLE
allow setup.py to be run without specifying "python" at the beginning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from setuptools import setup, find_packages
 import os
 


### PR DESCRIPTION
Just a simple addition to setup.py allows it to be run like this:

    ./setup.py install

instead of:

    python setup.py install

Not a big deal, but is convenient.