### PR TITLE
Make `slides` a phony target

### DIFF
--- a/src/hieroglyph/quickstart.py
+++ b/src/hieroglyph/quickstart.py
@@ -52,6 +52,7 @@ slide_levels = 3
 
 sphinx.quickstart.MAKEFILE += u"""
 
+.PHONY: slides
 slides:
 	$(SPHINXBUILD) -b slides $(ALLSPHINXOPTS) $(BUILDDIR)/slides
 	@echo "Build finished. The HTML slides are in $(BUILDDIR)/slides."


### PR DESCRIPTION
Otherwise creating a file or directory named `slides` will make `make slides` think it should build the file/directory target.