### PR TITLE
repaired links to Sphinx docs

### DIFF
--- a/docs/theme-creation.rst
+++ b/docs/theme-creation.rst
@@ -15,9 +15,10 @@ To create a new theme, follow these steps:
 #. Create a directory for your theme.
 
    This directory will need to be somewhere Sphinx and Hieroglyph can
-   find it. You can set the `html_theme_path`_ in your project to the
-   path, if needed. If you plan to distribute your theme, simply add
-   the `sphinx_themes entry point`_.
+   find it. You can set the ``slide_theme_path`` (in analogy to
+   `html_theme_path`_) in your project to the path, if needed. If you
+   plan to distribute your theme, simply add the `sphinx_themes entry
+   point`_.
 
 
 #. Create a ``theme.conf``
@@ -36,7 +37,7 @@ To create a new theme, follow these steps:
 
 #. Create a ``slide.html`` file.
 
-   The ``slide.html`` template is rendered for each individual slide. 
+   The ``slide.html`` template is rendered for each individual slide.
 
 #. Specify additional pages to generate in the ``theme.conf``
 
@@ -117,7 +118,7 @@ following variables are available for your templates:
     The slide number for the current slide.
 
 ``config``
-    A reference to the `Sphinx Configuration`_. 
+    A reference to the `Sphinx Configuration`_.
 
 Additional Pages
 ================

--- a/docs/theme-creation.rst
+++ b/docs/theme-creation.rst
@@ -136,11 +136,11 @@ The value of the key (``console.html`` in this case) specifies the
 template to use to render the page.
 
 
-.. _`themes`: http://sphinx.pocoo.org/theming.html
-.. _`describes what goes into theme.conf`: http://sphinx-doc.org/theming.html#creating-themes
-.. _`sphinx_themes entry point`: http://sphinx-doc.org/theming.html#using-a-theme
-.. _`html_theme_path`: http://sphinx-doc.org/config.html#confval-html_theme_path
-.. _pathto: http://sphinx-doc.org/templating.html#pathto
+.. _`themes`: http://www.sphinx-doc.org/en/master/theming.html
+.. _`describes what goes into theme.conf`: http://www.sphinx-doc.org/en/master/theming.html#creating-themes
+.. _`sphinx_themes entry point`: http://www.sphinx-doc.org/en/master/theming.html#using-a-theme
+.. _`html_theme_path`: http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_theme_path
+.. _pathto: http://www.sphinx-doc.org/en/master/templating.html#pathto
 .. _Jinja: http://jinja.pocoo.org/
-.. _`Sphinx templating`: http://sphinx-doc.org/templating.html
-.. _`Sphinx Configuration`: http://sphinx-doc.org/config.html#general-configuration
+.. _`Sphinx templating`: http://www.sphinx-doc.org/en/master/templating.html
+.. _`Sphinx Configuration`: http://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/hieroglyph/quickstart.py
+++ b/src/hieroglyph/quickstart.py
@@ -37,11 +37,9 @@ some basic Sphinx questions.
     if 'project' not in d:
         print('''
 The presentation title will be included on the title slide.''')
-        d['project'] = sphinx_quickstart.do_prompt('project',
-                                                   'Presentation title')
+        d['project'] = sphinx_quickstart.do_prompt('Presentation title')
     if 'author' not in d:
-        d['author'] = sphinx_quickstart.do_prompt('author',
-                                                  'Author name(s)')
+        d['author'] = sphinx_quickstart.do_prompt('Author name(s)')
 
     # slide_theme
     theme_entrypoints = pkg_resources.iter_entry_points('hieroglyph.theme')

--- a/src/hieroglyph/quickstart.py
+++ b/src/hieroglyph/quickstart.py
@@ -7,14 +7,14 @@ import os
 
 import pkg_resources
 from sphinx import version_info as sphinx_version_info
-import sphinx.quickstart
+import sphinx.cmd.quickstart as sphinx_quickstart
 from sphinx.util.console import bold
 
 from hieroglyph import version
 
 
 def ask_user(d):
-    """Wrap sphinx.quickstart.ask_user, and add additional questions."""
+    """Wrap sphinx.cmd.quickstart.ask_user, and add additional questions."""
 
     # Print welcome message
     msg = bold('Welcome to the Hieroglyph %s quickstart utility.') % (
@@ -37,9 +37,11 @@ some basic Sphinx questions.
     if 'project' not in d:
         print('''
 The presentation title will be included on the title slide.''')
-        sphinx.quickstart.do_prompt(d, 'project', 'Presentation title')
+        d['project'] = sphinx_quickstart.do_prompt('project',
+                                                   'Presentation title')
     if 'author' not in d:
-        sphinx.quickstart.do_prompt(d, 'author', 'Author name(s)')
+        d['author'] = sphinx_quickstart.do_prompt('author',
+                                                  'Author name(s)')
 
     # slide_theme
     theme_entrypoints = pkg_resources.iter_entry_points('hieroglyph.theme')
@@ -64,16 +66,17 @@ Available themes:
     msg += """Which theme would you like to use?"""
     print(msg)
 
-    sphinx.quickstart.do_prompt(
-        d, 'slide_theme', 'Slide Theme', themes[0]['name'],
-        sphinx.quickstart.choice(
+    d['slide_theme'] = sphinx_quickstart.do_prompt(
+        'Slide Theme',
+        themes[0]['name'],
+        sphinx_quickstart.choice(
             *[t['name'] for t in themes]
         ),
     )
 
     # Ask original questions
     print("")
-    sphinx.quickstart.ask_user(d)
+    sphinx_quickstart.ask_user(d)
 
 
 def quickstart(path=None):
@@ -84,14 +87,14 @@ def quickstart(path=None):
 
     templatedir = os.path.join(os.path.dirname(__file__), 'templates')
 
-    d = sphinx.quickstart.DEFAULT_VALUE.copy()
+    d = sphinx_quickstart.DEFAULTS.copy()
     d['extensions'] = ['hieroglyph']
-    d.update(dict(("ext_" + ext, False) for ext in sphinx.quickstart.EXTENSIONS))
+    d.update(dict(("ext_" + ext, False) for ext in sphinx_quickstart.EXTENSIONS))
     if path:
         d['path'] = path
 
     ask_user(d)
-    sphinx.quickstart.generate(d, templatedir=templatedir)
+    sphinx_quickstart.generate(d, templatedir=templatedir)
 
 
 def main():

--- a/src/hieroglyph/tests/test_quickstart.py
+++ b/src/hieroglyph/tests/test_quickstart.py
@@ -7,7 +7,7 @@ import time
 from unittest import TestCase
 
 from six import PY2, text_type
-from sphinx import quickstart as sphinx_quickstart
+from sphinx.cmd import quickstart as sphinx_quickstart
 from sphinx.util.pycompat import execfile_
 from sphinx.util.console import nocolor, coloron
 
@@ -62,6 +62,13 @@ class TestQuickstart(TestCase):
         assert os.path.exists(conffile)
         ns = {}
         execfile_(conffile, ns)
+
+        # XXX why is there a list in the list?!
+        # Apparently introduced between Sphinx 1.6.7 and 1.7.0b1
+        if type(ns['extensions']) is list:
+            # let's make sure there is nothing we don't expect
+            self.assertEqual(len(ns['extensions']), 1)
+            ns['extensions'] = ns['extensions'][0]
 
         self.assertIn('hieroglyph', ns['extensions'])
         self.assertEqual(ns['templates_path'], ['_templates'])

--- a/src/hieroglyph/tests/test_translator.py
+++ b/src/hieroglyph/tests/test_translator.py
@@ -261,7 +261,12 @@ Slide ``Title``
 
                 # Sphinx 1.3
                 'Slide <code class="docutils literal">'
-                '<span class="pre">Title</span></code>'
+                '<span class="pre">Title</span></code>',
+
+                # Sphinx >= 1.7.0b1
+                # (see http://www.sphinx-doc.org/en/master/changes.html)
+                'Slide <code class="docutils literal notranslate">'
+                '<span class="pre">Title</span></code>',
 
             ],
         )

--- a/src/hieroglyph/themes/slides2/layout.html
+++ b/src/hieroglyph/themes/slides2/layout.html
@@ -59,7 +59,7 @@ URL: https://code.google.com/p/io-2012-slides
         href="{{ pathto('_static/theme/css/hieroglyph.css', 1) }}">
   <link rel="stylesheet" media="only screen and (max-device-width: 480px)"
         href="{{ pathto('_static/theme/css/phone.css', 1) }}">
-
+  <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
   <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
   {% if theme_custom_css %}
   <link rel="stylesheet" href="{{ pathto('_static/' + theme_custom_css, 1) }}"


### PR DESCRIPTION
Sphinx docs moved from ``http://sphinx-doc.org/`` to ``http://www.sphinx-doc.org/en/master/``.