### PR TITLE
fix option ``stylesheet`` in ``theme.conf`` for slides2

### DIFF
--- a/src/hieroglyph/themes/slides2/layout.html
+++ b/src/hieroglyph/themes/slides2/layout.html
@@ -59,7 +59,7 @@ URL: https://code.google.com/p/io-2012-slides
         href="{{ pathto('_static/theme/css/hieroglyph.css', 1) }}">
   <link rel="stylesheet" media="only screen and (max-device-width: 480px)"
         href="{{ pathto('_static/theme/css/phone.css', 1) }}">
-
+  <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
   <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
   {% if theme_custom_css %}
   <link rel="stylesheet" href="{{ pathto('_static/' + theme_custom_css, 1) }}"


### PR DESCRIPTION
For ``slides2``, the option ``stylesheet`` in ``theme.conf`` (INI section ``theme``) did not work for me.

The theme's configuration file uses this option as well:
https://github.com/nyergler/hieroglyph/blob/1ef062fad5060006566f8d6bd3b5a231ac7e0488/src/hieroglyph/themes/slides2/theme.conf#L1-L3 

However, ``slides.css`` never appeared in the HTML source.

Fixing this is handy for inheriting from ``slides2``.