### PR TITLE
repaired links to Sphinx docs

### DIFF
--- a/docs/theme-creation.rst
+++ b/docs/theme-creation.rst
@@ -136,11 +136,11 @@ The value of the key (``console.html`` in this case) specifies the
 template to use to render the page.
 
 
-.. _`themes`: http://sphinx.pocoo.org/theming.html
-.. _`describes what goes into theme.conf`: http://sphinx-doc.org/theming.html#creating-themes
-.. _`sphinx_themes entry point`: http://sphinx-doc.org/theming.html#using-a-theme
-.. _`html_theme_path`: http://sphinx-doc.org/config.html#confval-html_theme_path
-.. _pathto: http://sphinx-doc.org/templating.html#pathto
+.. _`themes`: http://www.sphinx-doc.org/en/master/theming.html
+.. _`describes what goes into theme.conf`: http://www.sphinx-doc.org/en/master/theming.html#creating-themes
+.. _`sphinx_themes entry point`: http://www.sphinx-doc.org/en/master/theming.html#using-a-theme
+.. _`html_theme_path`: http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_theme_path
+.. _pathto: http://www.sphinx-doc.org/en/master/templating.html#pathto
 .. _Jinja: http://jinja.pocoo.org/
-.. _`Sphinx templating`: http://sphinx-doc.org/templating.html
-.. _`Sphinx Configuration`: http://sphinx-doc.org/config.html#general-configuration
+.. _`Sphinx templating`: http://www.sphinx-doc.org/en/master/templating.html
+.. _`Sphinx Configuration`: http://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
Sphinx docs moved from ``http://sphinx-doc.org/`` to ``http://www.sphinx-doc.org/en/master/``.