### PR TITLE
Fix test battery failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - SPHINX_SPEC='==1.7.0'
   - SPHINX_SPEC='==1.8.0'
   - SPHINX_SPEC='==2.0.0'
+  # latest release
   - SPHINX_SPEC=''
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ python:
   - "3.7"
 
 env:
-  - SPHINX_SPEC='==1.4.0'
-  - SPHINX_SPEC='==1.5.0'
-  - SPHINX_SPEC='==1.6.1'
-  - SPHINX_SPEC='==1.7.0'
-  - SPHINX_SPEC='==1.8.0'
-  - SPHINX_SPEC='==2.0.0'
+  - SPHINX_SPEC='~=1.7.0'
+  - SPHINX_SPEC='~=1.8.0'
+  - SPHINX_SPEC='~=2.0.0'
+  - SPHINX_SPEC='~=2.1.0'
   # latest release
   - SPHINX_SPEC=''
 
@@ -21,7 +19,11 @@ matrix:
   - python:
       "2.7"
     env:
-      SPHINX_SPEC='==2.0.0'
+      SPHINX_SPEC='~=2.0.0'
+  - python:
+      "2.7"
+    env:
+      SPHINX_SPEC='~=2.1.0'
 
 install:
   - pip install coveralls sphinx_rtd_theme "sphinx${SPHINX_SPEC:-}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ env:
 matrix:
   # exclude non Python2 compatible Sphinx versions
   exclude:
-  - python: 2.7
-    env: SPHINX_SPEC='==2.0.0'
+  - python:
+      "2.7"
+    env:
+      SPHINX_SPEC='==2.0.0'
 
 install:
   - pip install coveralls sphinx_rtd_theme "sphinx${SPHINX_SPEC:-}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,31 @@
+cache: pip
+dist: xenial
 language: python
 python:
   - "2.7"
-  - "3.6"
+  - "3.7"
 
 env:
-  - SPHINX_SPEC=Sphinx~=1.4.0
-  - SPHINX_SPEC=Sphinx~=1.5.0
-  - SPHINX_SPEC=Sphinx~=1.6.0
-  - SPHINX_SPEC=git+https://github.com/sphinx-doc/sphinx.git\#egg\=Sphinx-dev
+  - SPHINX_SPEC='==1.4.0'
+  - SPHINX_SPEC='==1.5.0'
+  - SPHINX_SPEC='==1.6.1'
+  - SPHINX_SPEC='==1.7.0'
+  - SPHINX_SPEC='==1.8.0'
+  - SPHINX_SPEC='==2.0.0'
+  - SPHINX_SPEC=''
 
-# before_install:
-#   - bundle install
+matrix:
+  # exclude non Python2 compatible Sphinx versions
+  exclude:
+  - python: 2.7
+    env: SPHINX_SPEC='==2.0.0'
 
 install:
-  - pip install coveralls
-  - pip install sphinx_rtd_theme
-  - pip install $SPHINX_SPEC --allow-external Sphinx --allow-unverified Sphinx
+  - pip install coveralls sphinx_rtd_theme "sphinx${SPHINX_SPEC:-}"
   - python setup.py install
 
 script:
   - coverage run --source=hieroglyph setup.py test
-  # - rake jasmine:ci JASMINE_CONFIG_PATH=./src/jstests/jasmine.yml
   - cd docs; READTHEDOCS=True SPHINXOPTS="-NqW" SPHINXBUILD="sphinx-build" make -e clean html slides
 
 after_success:

--- a/src/hieroglyph/tests/test_translator.py
+++ b/src/hieroglyph/tests/test_translator.py
@@ -261,6 +261,10 @@ Slide ``Title``
 
                 # Sphinx 1.3
                 'Slide <code class="docutils literal">'
+                '<span class="pre">Title</span></code>',
+
+                # Sphinx 1.7 @Python3.7
+                'Slide <code class="docutils literal notranslate">'
                 '<span class="pre">Title</span></code>'
 
             ],

--- a/src/hieroglyph/tests/test_translator.py
+++ b/src/hieroglyph/tests/test_translator.py
@@ -253,7 +253,7 @@ Slide ``Title``
         self.document.walkabout(self.translator)
 
         self.assertIn(
-            self.translator.slide_data[-1].title,
+            str(self.translator.slide_data[-1].title),
             [
                 # Sphinx 1.1, 1.2
                 'Slide <tt class="docutils literal">'


### PR DESCRIPTION
Summary:

* Tests for Sphinx <=1.6.1 should now pass.
* Tests for Sphinx >=1.7.0 should now fail for legitimate reasons.

Changes:

* Add Sphinx versions more recent than `1.6.0` to the test battery.
* Fix `pip install`.
* Fix an unhappy test.