### PR TITLE
Return to project directory after building docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 
 script:
   - coverage run --source=hieroglyph setup.py test
-  - cd docs; READTHEDOCS=True SPHINXOPTS="-NqW" SPHINXBUILD="sphinx-build" make -e clean html slides
+  - cd docs; READTHEDOCS=True SPHINXOPTS="-NqW" SPHINXBUILD="sphinx-build" make -e clean html slides; cd ..
 
 after_success:
   - coveralls


### PR DESCRIPTION
We started building the docs as an indirect integration test. However, because the working directory changed between generating the coverage file and the Travis `after_success` hook, `coveralls` was unable to find the coverage file.

This commit updates the Travis configuration to return to the project root directory so that coverage reporting is accurate.